### PR TITLE
added path to paginated page object

### DIFF
--- a/metalsmith-collections-paginate.js
+++ b/metalsmith-collections-paginate.js
@@ -59,10 +59,11 @@ module.exports = function (opts) {
 
         // Render the first page differently to the rest, when set.
         if (i === 0 && pageOpts.first) {
-          files[interpolate(pageOpts.first, page.paginate)] = page;
+          page.path = interpolate(pageOpts.first, page.paginate);
         } else {
-          files[interpolate(pageOpts.path, page.paginate)] = page;
+          page.path = interpolate(pageOpts.path, page.paginate);
         }
+        files[page.path] = page;
 
         // Update next/prev references.
         if (pages[i - 1]) {

--- a/test.js
+++ b/test.js
@@ -33,8 +33,18 @@ describe('metalsmith collections paginate', function () {
         }
       })(files, metalsmith, function (err) {
         expect(files['articles/index.html']).to.exist;
+        expect(files['articles/index.html'].paginate.next.path).to.equal(
+          'articles/page/2/index.html'
+        );
         expect(files['articles/page/2/index.html']).to.exist;
+        expect(files['articles/page/2/index.html'].paginate.previous.path).to
+          .equal('articles/index.html');
+        expect(files['articles/page/2/index.html'].paginate.next.path).to.equal(
+          'articles/page/3/index.html'
+        );
         expect(files['articles/page/3/index.html']).to.exist;
+        expect(files['articles/page/3/index.html'].paginate.previous.path).to
+          .equal('articles/page/2/index.html');
 
         expect(metadata.collections.articles.pages).to.have.length(3);
 


### PR DESCRIPTION
Let me know if this can be worked in. It saves tons of logic and stuff on the template side of things. It does keep in the 'index.html' which isn't so clean, but it's pretty easy to write a template plugin to strip that out.
