### PR TITLE
Add the ability to add arbitrary metadata to the created pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,19 @@ metalsmith.use(paginate({
     perPage: 5,
     template: 'index.jade',
     first: 'index.html',
-    path: 'page/:num/index.html'
+    path: 'page/:num/index.html',
+    pageMetadata: {
+      title: 'Articles Archive'
+    }
   }
 }));
 ```
+
+The `pageMetadata` option is optional. The object passed as `pageMetadata`
+is used as the base for any created pages metadata. This allows for adding
+arbitrary metadata to the created pages like a page title variable, allowing
+for more reuse of list page templates.
+
 
 ### Template
 

--- a/metalsmith-collections-paginate.js
+++ b/metalsmith-collections-paginate.js
@@ -54,12 +54,12 @@ module.exports = function (opts) {
         };
 
         // Generate a new file based on the filename with correct metadata.
-        var page = {
+        var page = extend({}, pageOpts.pageMetadata, {
           template: pageOpts.template,
           contents: new Buffer(''),
           path:     interpolate(pageOpts.path, paginate),
           paginate: paginate
-        };
+        });
 
         // Create the file.
         files[page.path] = page;

--- a/test.js
+++ b/test.js
@@ -76,6 +76,44 @@ describe('metalsmith collections paginate', function () {
         return done(err);
       });
     });
+
+    it('should add metadata to pages created', function (done) {
+      return paginate({
+        articles: {
+          perPage: 3,
+          template: 'index.jade',
+          pageMetadata: {
+            foo: 'bar',
+            some: {
+              thing: true
+            }
+          }
+        }
+      })(files, metalsmith, function (err) {
+        var firstPage = files['articles/index.html'];
+        var pageOne   = files['articles/page/1/index.html'];
+        var pageTwo   = files['articles/page/2/index.html'];
+        var pageThree = files['articles/page/3/index.html'];
+
+        expect(firstPage).to.exist;
+        expect(firstPage.foo).to.equal('bar');
+        expect(firstPage.some.thing).to.equal(true);
+
+        expect(pageOne).to.exist;
+        expect(pageOne.foo).to.equal('bar');
+        expect(pageOne.some.thing).to.equal(true);
+
+        expect(pageTwo).to.exist;
+        expect(pageTwo.foo).to.equal('bar');
+        expect(pageTwo.some.thing).to.equal(true);
+
+        expect(pageThree).to.exist;
+        expect(pageThree.foo).to.equal('bar');
+        expect(pageThree.some.thing).to.equal(true);
+
+        return done(err);
+      });
+    });
   });
 
   describe('missing collection', function () {


### PR DESCRIPTION
This enables the created pages to have arbitrarily complex metadata passed in via configuration.
